### PR TITLE
fix AddDuplicateBehavior.Update

### DIFF
--- a/KdTreeLib/KdTree.cs
+++ b/KdTreeLib/KdTree.cs
@@ -78,7 +78,7 @@ namespace KdTree
 
 							case AddDuplicateBehavior.Update:
 								parent.Value = value;
-								break;
+								return true;
 
 							default:
 								// Should never happen

--- a/KdTreeTestsLib/KdTreeTests.cs
+++ b/KdTreeTestsLib/KdTreeTests.cs
@@ -117,11 +117,15 @@ namespace KdTree.Tests
 
 			var newValue = "I love chicken, I love liver, Meow Mix Meow Mix please deliver";
 
+			var olcCount = tree.Count();
+
 			tree.Add(testNodes[0].Point, newValue);
 
 			var actualValue = tree.FindValueAt(testNodes[0].Point);
+			var newCount = tree.Count();
 
 			Assert.AreEqual(newValue, actualValue);
+			Assert.AreEqual(olcCount, newCount);
 		}
 
 		[TestMethod]


### PR DESCRIPTION
Possibly bug in `Add` method with `Update` behavior.
A value was not updated and newly added with the same key.